### PR TITLE
[엄성민] 견적 생성 및 업데이트 api 구현

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from "express";
 import { asyncHandler } from "../middleware/error.middleware";
 import authService from "../servieces/auth.service";
 
+// 로그인 컨트롤러
 const logInController: RequestHandler = asyncHandler(async (req, res, next) => {
   const { email, password, role } = req.body;
   const logInDto = { email, password, role };
@@ -10,6 +11,7 @@ const logInController: RequestHandler = asyncHandler(async (req, res, next) => {
   res.status(200).send({ accessToken, refreshToken });
 });
 
+// 회원가입 컨트롤러
 const signUpController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const { email, password, name, phoneNumber, role } = req.body;
@@ -22,6 +24,7 @@ const signUpController: RequestHandler = asyncHandler(
   }
 );
 
+// 리프레쉬 토큰 컨트롤러
 const refreshTokenController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const { refreshToken } = req.body;

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,14 +1,16 @@
 import { RequestHandler } from "express";
 import { asyncHandler } from "../middleware/error.middleware";
 import authService from "../servieces/auth.service";
+import userService from "../servieces/user.service";
 
 // 로그인 컨트롤러
 const logInController: RequestHandler = asyncHandler(async (req, res, next) => {
   const { email, password, role } = req.body;
   const logInDto = { email, password, role };
   const { sub, accessToken, refreshToken } = await authService.logIn(logInDto);
+  const { hasProfile } = await userService.getUserMe(sub);
   req.userId = sub;
-  res.status(200).send({ accessToken, refreshToken });
+  res.status(200).send({ accessToken, refreshToken, hasProfile, role });
 });
 
 // 회원가입 컨트롤러

--- a/src/controllers/estimate-request.controller.ts
+++ b/src/controllers/estimate-request.controller.ts
@@ -2,6 +2,11 @@ import { RequestHandler } from "express";
 import { asyncHandler } from "../middleware/error.middleware";
 import { EstimateRequstDto } from "../types/estimate-request.type";
 import estimateRequstService from "../servieces/estimate-request.sevice";
+import {
+  findActiveEstimateRequests,
+  findInactiveEstimateRequests,
+} from "../servieces/utills";
+import estimateService from "../servieces/estimate.service";
 
 // 견적 요청 생성하기
 const createEstimateRequestController: RequestHandler = asyncHandler(
@@ -30,9 +35,108 @@ const deleteEstimateRequestController: RequestHandler = asyncHandler(
   }
 );
 
+// 일반 유저 받았던 견적 요청들
+const getEstimateRequestsController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const customerId = req.userId as string;
+    const inactiveEstimateRequests = await findInactiveEstimateRequests(
+      customerId
+    );
+    const estimateRequests = await Promise.all(
+      inactiveEstimateRequests.map(async (inactiveEstimateRequest) => {
+        const {
+          id,
+          createdAt,
+          serviceType,
+          movingDate,
+          departure,
+          destination,
+        } = inactiveEstimateRequest;
+        return {
+          id,
+          requestDate: createdAt,
+          serviceType,
+          movingDate,
+          destination,
+          departure,
+        };
+      })
+    );
+    res.status(200).send(estimateRequests);
+  }
+);
+
+// 필터기능 추가할 예정, 고객 이름 추가로 주기, orderBy만 먼저 적용함,
+const getRequsetEstimateRequestsController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const workerId = req.userId as string;
+    const { orderBy } = req.query;
+
+    const estimateRequests = await findActiveEstimateRequests();
+    const assignedEstimates = await estimateService.getAssignedEstimate(
+      workerId,
+      false
+    );
+
+    const assignedCustomerIds = new Set(
+      assignedEstimates.map((estimate) => estimate.customerId)
+    );
+
+    const filteredEstimateRequests = estimateRequests.filter(
+      (req) => !assignedCustomerIds.has(req.customerId)
+    );
+
+    const formattedEstimateRequests = filteredEstimateRequests.map(
+      (estimateRequest) => ({
+        id: estimateRequest.id,
+        customerId: estimateRequest.customerId,
+        serviceType: estimateRequest.serviceType,
+        movingDate: estimateRequest.movingDate,
+        departure: estimateRequest.departure,
+        destination: estimateRequest.destination,
+        createdAt: estimateRequest.createdAt,
+        updatedAt: estimateRequest.updatedAt,
+        status: null,
+      })
+    );
+
+    const formattedAssignedEstimates = assignedEstimates.map((estimate) => ({
+      id: estimate.id,
+      customerId: estimate.customerId,
+      serviceType: estimate.serviceType,
+      movingDate: estimate.movingDate,
+      departure: estimate.departure,
+      destination: estimate.destination,
+      createdAt: estimate.createdAt,
+      updatedAt: estimate.updatedAt,
+      status: estimate.status,
+    }));
+
+    const allEstimates = [
+      ...formattedAssignedEstimates,
+      ...formattedEstimateRequests,
+    ];
+
+    const sortedEstimates = allEstimates.sort((a, b) => {
+      if (orderBy === "createdAt") {
+        return (
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        );
+      }
+      return (
+        new Date(a.movingDate).getTime() - new Date(b.movingDate).getTime()
+      );
+    });
+
+    res.status(200).send(sortedEstimates);
+  }
+);
+
 const estimateRequest = {
   createEstimateRequestController,
   deleteEstimateRequestController,
+  getEstimateRequestsController,
+  getRequsetEstimateRequestsController,
 };
 
 export default estimateRequest;

--- a/src/controllers/estimate-request.controller.ts
+++ b/src/controllers/estimate-request.controller.ts
@@ -3,6 +3,7 @@ import { asyncHandler } from "../middleware/error.middleware";
 import { EstimateRequstDto } from "../types/estimate-request.type";
 import estimateRequstService from "../servieces/estimate-request.sevice";
 
+// 견적 요청 생성하기
 const createEstimateRequestController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const { serviceType, departure, destination, movingDate } = req.body;
@@ -20,6 +21,7 @@ const createEstimateRequestController: RequestHandler = asyncHandler(
   }
 );
 
+// 견적 요청 삭제하기
 const deleteEstimateRequestController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const customerId = req.userId as string;

--- a/src/controllers/estimate.controller.ts
+++ b/src/controllers/estimate.controller.ts
@@ -1,0 +1,86 @@
+import { RequestHandler } from "express";
+import { asyncHandler } from "../middleware/error.middleware";
+import estimateService from "../servieces/estimate.service";
+import estimateRequstService from "../servieces/estimate-request.sevice";
+
+//일반 유저가 지정 견적 생성 (일반 유저가 기사 유저에게 견적 보내기)
+const createAssignedEstimateController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const { workerId } = req.params;
+    if (typeof workerId !== "string")
+      throw new Error("400/workerId is invalid");
+    const customerId = req.userId as string;
+    // 지정 견적 생성
+    await estimateService.createEstimate(workerId, customerId, "assigned");
+    res.sendStatus(201);
+  }
+);
+
+//일반 유저가 견적 확정하기 가격확인해야함함
+const confirmEstimateController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const { estimateId } = req.params;
+    const customerId = req.userId as string;
+    if (typeof estimateId !== "string")
+      throw new Error("400/workerId is invalid");
+    // isCompleted ->ture로 변경
+    await estimateService.confirmEstimate(estimateId);
+    // 유저의 견적 요청 상태값 변경경
+    await estimateRequstService.confirmEstimateRequest(customerId);
+    res.sendStatus(204);
+  }
+);
+
+//기사 유저가 견적 생성하기 (기사유저가 일반 유저에게 견적 보내기)
+const createGeneralEstimateController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const { customerId } = req.params;
+    const { price } = req.body;
+    const workerId = req.userId as string;
+    if (typeof customerId !== "string")
+      throw new Error("400/workerId is invalid");
+    // 일반 견적 생성
+    await estimateService.createEstimate(
+      workerId,
+      customerId,
+      "general",
+      price
+    );
+    res.sendStatus(201);
+  }
+);
+
+// 기사 유저가 지정 견적 반려하기
+const rejectEstimateController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const { estimateId } = req.params;
+    const { rejectionMessage } = req.body;
+    if (typeof estimateId !== "string")
+      throw new Error("400/workerId is invalid");
+    await estimateService.rejectEstimate(estimateId, rejectionMessage);
+    res.sendStatus(204);
+  }
+);
+
+// 기사 유저가 지정 견적에 가격을 업데이트
+const PriceEstimateController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const { estimateId } = req.params;
+    const { price, comment } = req.body;
+    if (typeof estimateId !== "string")
+      throw new Error("400/workerId is invalid");
+
+    await estimateService.priceEstimate(estimateId, price, comment);
+    res.sendStatus(204);
+  }
+);
+
+const estimate = {
+  createAssignedEstimateController,
+  confirmEstimateController,
+  createGeneralEstimateController,
+  rejectEstimateController,
+  PriceEstimateController,
+};
+
+export default estimate;

--- a/src/controllers/estimate.controller.ts
+++ b/src/controllers/estimate.controller.ts
@@ -2,6 +2,8 @@ import { RequestHandler } from "express";
 import { asyncHandler } from "../middleware/error.middleware";
 import estimateService from "../servieces/estimate.service";
 import estimateRequstService from "../servieces/estimate-request.sevice";
+import profileService from "../servieces/profile.service";
+import { findInactiveEstimateRequests } from "../servieces/utills";
 
 //일반 유저가 지정 견적 생성 (일반 유저가 기사 유저에게 견적 보내기)
 const createAssignedEstimateController: RequestHandler = asyncHandler(
@@ -23,7 +25,7 @@ const confirmEstimateController: RequestHandler = asyncHandler(
     const customerId = req.userId as string;
     if (typeof estimateId !== "string")
       throw new Error("400/workerId is invalid");
-    // isCompleted ->ture로 변경
+    // isConfirmed ->ture로 변경
     await estimateService.confirmEstimate(estimateId);
     // 유저의 견적 요청 상태값 변경경
     await estimateRequstService.confirmEstimateRequest(customerId);
@@ -63,7 +65,7 @@ const rejectEstimateController: RequestHandler = asyncHandler(
 );
 
 // 기사 유저가 지정 견적에 가격을 업데이트
-const PriceEstimateController: RequestHandler = asyncHandler(
+const priceEstimateController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const { estimateId } = req.params;
     const { price, comment } = req.body;
@@ -74,13 +76,196 @@ const PriceEstimateController: RequestHandler = asyncHandler(
     res.sendStatus(204);
   }
 );
+//일반 유저 대기중인 견적 get
+//나중에 추가해야하는것
+//workerFavoritesCount
+//workerReviewsCount
+//workerRating
+//workerConfirmedEstimatesCount
+const getPendingEstimatesController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const customerId = req.userId as string;
+
+    const pendingEstimates = await estimateService.getPendingEstimates(
+      customerId
+    );
+    const mergedData = await Promise.all(
+      pendingEstimates.map(async (estimate) => {
+        const {
+          id,
+          price,
+          serviceType,
+          status,
+          movingDate,
+          departure,
+          destination,
+          isConfirmed,
+          workerId,
+        } = estimate;
+
+        return {
+          id,
+          price: price ? price : null,
+          serviceType: serviceType,
+          status,
+          movingDate,
+          departure,
+          destination,
+          isConfirmed,
+          workerId,
+        };
+      })
+    );
+
+    res.status(200).send(mergedData);
+  }
+);
+
+const getEstimatesController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const { estimateRequestId } = req.params;
+    const estimates = await estimateService.getEstimatesByEstimateRequestId(
+      estimateRequestId
+    );
+    const mergedData = await Promise.all(
+      estimates.map(async (estimate) => {
+        const {
+          id,
+          price,
+          serviceType,
+          status,
+          movingDate,
+          departure,
+          destination,
+          isConfirmed,
+          workerId,
+        } = estimate;
+
+        return {
+          id,
+          price: price ? price : null,
+          serviceType: serviceType,
+          status,
+          movingDate,
+          departure,
+          destination,
+          isConfirmed,
+          workerId,
+        };
+      })
+    );
+
+    res.status(200).send(mergedData);
+  }
+);
+
+const getEstimateDetailController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const { estimateId } = req.params;
+    const estimate = await estimateService.getEstimateByEstimatetId(estimateId);
+    const {
+      id,
+      price,
+      serviceType,
+      status,
+      movingDate,
+      departure,
+      destination,
+      isConfirmed,
+      workerId,
+    } = estimate;
+    const data = {
+      id,
+      price: price ? price : null,
+      serviceType: serviceType,
+      status,
+      movingDate,
+      departure,
+      destination,
+      isConfirmed,
+      workerId,
+    };
+    res.status(200).send(data);
+  }
+);
+
+const getSentEstimatesController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const workerId = req.userId as string;
+    const estimates = await estimateService.getSentEstimates(workerId);
+
+    const data = estimates.map(
+      ({
+        id,
+        customerId,
+        serviceType,
+        movingDate,
+        departure,
+        destination,
+        createdAt,
+        updatedAt,
+        status,
+      }) => ({
+        id,
+        customerId,
+        serviceType,
+        movingDate,
+        departure,
+        destination,
+        createdAt,
+        updatedAt,
+        status,
+      })
+    );
+
+    res.status(200).send(data);
+  }
+);
+
+const getRejectEstimatesController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const workerId = req.userId as string;
+    const estimates = await estimateService.getRejectEstimates(workerId);
+
+    const data = estimates.map(
+      ({
+        id,
+        customerId,
+        serviceType,
+        movingDate,
+        departure,
+        destination,
+        createdAt,
+        updatedAt,
+        status,
+      }) => ({
+        id,
+        customerId,
+        serviceType,
+        movingDate,
+        departure,
+        destination,
+        createdAt,
+        updatedAt,
+        status,
+      })
+    );
+
+    res.status(200).send(data);
+  }
+);
 
 const estimate = {
   createAssignedEstimateController,
   confirmEstimateController,
   createGeneralEstimateController,
   rejectEstimateController,
-  PriceEstimateController,
+  priceEstimateController,
+  getPendingEstimatesController,
+  getEstimatesController,
+  getEstimateDetailController,
+  getSentEstimatesController,
+  getRejectEstimatesController,
 };
 
 export default estimate;

--- a/src/controllers/profile.controller.ts
+++ b/src/controllers/profile.controller.ts
@@ -122,11 +122,26 @@ const updateWorkerProfileController: RequestHandler = asyncHandler(
   }
 );
 
+const getWorkerProfileController: RequestHandler = asyncHandler(
+  async (req, res, next) => {
+    const { workerId } = req.params;
+    const { experience, nickname, profileImage } =
+      await profileService.getWorkerProfile(workerId);
+
+    res.status(200).send({
+      workerProfileImage: profileImage,
+      workerNickname: nickname,
+      workerExperience: experience,
+    });
+  }
+);
+
 const profile = {
   createWorkerProfileController,
   createCustomerProfileController,
   updateCustomerProfileController,
   updateWorkerProfileController,
+  getWorkerProfileController,
 };
 
 export default profile;

--- a/src/controllers/profile.controller.ts
+++ b/src/controllers/profile.controller.ts
@@ -3,6 +3,7 @@ import { asyncHandler } from "../middleware/error.middleware";
 import { CustomerProfileDto, WorkerProfileDto } from "../types/profile.type";
 import profileService from "../servieces/profile.service";
 
+// 일반 유저 프로필 생성
 const createCustomerProfileController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const { livingArea, services } = req.body;
@@ -26,6 +27,7 @@ const createCustomerProfileController: RequestHandler = asyncHandler(
   }
 );
 
+// 기사 유저 프로필 생성
 const createWorkerProfileController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const {
@@ -62,6 +64,7 @@ const createWorkerProfileController: RequestHandler = asyncHandler(
   }
 );
 
+// 일반 유저 프로필 수정
 const updateCustomerProfileController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const { livingArea, services } = req.body;
@@ -84,6 +87,7 @@ const updateCustomerProfileController: RequestHandler = asyncHandler(
   }
 );
 
+// 기사 유저 프로필 수정
 const updateWorkerProfileController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const {

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -3,6 +3,7 @@ import { asyncHandler } from "../middleware/error.middleware";
 import userService from "../servieces/user.service";
 import { UpdateUserDto } from "../types/auth.type";
 
+// 내정보 가저오기 : 이름 프로필 이미지 , 프로필 생성 여부
 const getUserMeController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const userId = req.userId as string;
@@ -12,6 +13,7 @@ const getUserMeController: RequestHandler = asyncHandler(
   }
 );
 
+// 유저 정보 업데이트 : 이름 , 이메일 , 전화번호, 비밀번호
 const updateUserMeController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const userId = req.userId as string;

--- a/src/db/prisma/migrations/20250404064848_/migration.sql
+++ b/src/db/prisma/migrations/20250404064848_/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `isCompleted` on the `Estimate` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Estimate" DROP COLUMN "isCompleted",
+ADD COLUMN     "isConfirmed" BOOLEAN NOT NULL DEFAULT false;

--- a/src/db/prisma/migrations/20250404072512_/migration.sql
+++ b/src/db/prisma/migrations/20250404072512_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `nickname` on table `WorkerProfile` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "WorkerProfile" ALTER COLUMN "nickname" SET NOT NULL;

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -25,7 +25,7 @@ model User {
 model WorkerProfile {
   id           String        @id @default(uuid())
   profileImage String?
-  nickname     String?
+  nickname     String
   experience   Int
   summary      String
   description  String
@@ -88,7 +88,7 @@ model Estimate {
   departure         String
   destination       String
   price             Int?
-  isCompleted       Boolean         @default(false)
+  isConfirmed       Boolean         @default(false)
   createdAt         DateTime        @default(now())
   updatedAt         DateTime        @default(now())
   rejectionMessage  String?

--- a/src/routes/estimate-request.router.ts
+++ b/src/routes/estimate-request.router.ts
@@ -5,6 +5,7 @@ import { validateEstimateRequset } from "../vaildataions/estimate-requset.valida
 
 const estimateRequstRouter = express.Router();
 
+// 일반 유저가 견적 요청하기 생성
 estimateRequstRouter.post(
   "/",
   authenticatedOnly,
@@ -13,6 +14,7 @@ estimateRequstRouter.post(
   estimateRequest.createEstimateRequestController
 );
 
+// 일반 유저가 견적 요청하기 삭제
 estimateRequstRouter.delete(
   "/",
   authenticatedOnly,

--- a/src/routes/estimate-request.router.ts
+++ b/src/routes/estimate-request.router.ts
@@ -1,7 +1,12 @@
 import express from "express";
 import estimateRequest from "../controllers/estimate-request.controller";
-import { authenticatedOnly, customerOnly } from "../middleware/auth.middleware";
+import {
+  authenticatedOnly,
+  customerOnly,
+  workerOnly,
+} from "../middleware/auth.middleware";
 import { validateEstimateRequset } from "../vaildataions/estimate-requset.validation";
+import { workerData } from "worker_threads";
 
 const estimateRequstRouter = express.Router();
 
@@ -20,6 +25,21 @@ estimateRequstRouter.delete(
   authenticatedOnly,
   customerOnly,
   estimateRequest.deleteEstimateRequestController
+);
+
+//받았던 견적페이지에서 내가 보낸 견적적 요청 정보들
+estimateRequstRouter.get(
+  "/",
+  authenticatedOnly,
+  customerOnly,
+  estimateRequest.getEstimateRequestsController
+);
+
+estimateRequstRouter.get(
+  "/received",
+  authenticatedOnly,
+  workerOnly,
+  estimateRequest.getRequsetEstimateRequestsController
 );
 
 export default estimateRequstRouter;

--- a/src/routes/estimate.route.ts
+++ b/src/routes/estimate.route.ts
@@ -10,7 +10,7 @@ const estimateRouter = express.Router();
 
 // 일반 유저가 지정견적 생성하기
 estimateRouter.post(
-  "/assinged/:workerId",
+  "/assigned/:workerId",
   authenticatedOnly,
   customerOnly,
   estimate.createAssignedEstimateController
@@ -45,7 +45,44 @@ estimateRouter.put(
   "/price/:estimateId",
   authenticatedOnly,
   workerOnly,
-  estimate.PriceEstimateController
+  estimate.priceEstimateController
+);
+
+//일반 유저 대기중인 견적 get
+estimateRouter.get(
+  "/pending",
+  authenticatedOnly,
+  customerOnly,
+  estimate.getPendingEstimatesController
+);
+
+//받은 견적들 get
+estimateRouter.get(
+  "/received/:estimateRequestId",
+  authenticatedOnly,
+  estimate.getEstimatesController
+);
+
+//상세 견적 가져오기
+estimateRouter.get(
+  "/detail/:estimateId",
+  authenticatedOnly,
+  estimate.getEstimateDetailController
+);
+
+//보낸 견적 조회
+estimateRouter.get(
+  "/sent",
+  authenticatedOnly,
+  workerOnly,
+  estimate.getSentEstimatesController
+);
+// 반려한 요청 조회회
+estimateRouter.get(
+  "/reject",
+  authenticatedOnly,
+  workerOnly,
+  estimate.getRejectEstimatesController
 );
 
 export default estimateRouter;

--- a/src/routes/estimate.route.ts
+++ b/src/routes/estimate.route.ts
@@ -1,0 +1,51 @@
+import express from "express";
+import estimate from "../controllers/estimate.controller";
+import {
+  authenticatedOnly,
+  customerOnly,
+  workerOnly,
+} from "../middleware/auth.middleware";
+
+const estimateRouter = express.Router();
+
+// 일반 유저가 지정견적 생성하기
+estimateRouter.post(
+  "/assinged/:workerId",
+  authenticatedOnly,
+  customerOnly,
+  estimate.createAssignedEstimateController
+);
+
+// 일반 유저가 기사가 보낸 견적 확정하기
+estimateRouter.put(
+  "/confirm/:estimateId",
+  authenticatedOnly,
+  customerOnly,
+  estimate.confirmEstimateController
+);
+
+// 기사 유저가 일반 견적 생성하기
+estimateRouter.post(
+  "/general/:customerId",
+  authenticatedOnly,
+  workerOnly,
+  estimate.createGeneralEstimateController
+);
+
+//기사 유저가 지정 견적 거절하기
+estimateRouter.put(
+  "/reject/:estimateId",
+  authenticatedOnly,
+  workerOnly,
+  estimate.rejectEstimateController
+);
+
+//기사 유저가 지정 견적 가격 설정하기
+estimateRouter.put(
+  "/price/:estimateId",
+  authenticatedOnly,
+  workerOnly,
+  estimate.PriceEstimateController
+);
+
+export default estimateRouter;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import { authMiddleware } from "../middleware/auth.middleware";
 import profileRouter from "./profile.route";
 import userRouter from "./user.route";
 import estimateRequstRouter from "./estimate-request.router";
+import estimateRouter from "./estimate.route";
 
 const router = express.Router();
 
@@ -12,5 +13,6 @@ router.use("/auth", authRouter);
 router.use("/profile", profileRouter);
 router.use("/user", userRouter);
 router.use("/estimate-request", estimateRequstRouter);
+router.use("/estimate", estimateRouter);
 
 export default router;

--- a/src/routes/profile.route.ts
+++ b/src/routes/profile.route.ts
@@ -10,10 +10,10 @@ import {
   validateCustomerProfile,
   validateWorkerProfile,
 } from "../vaildataions/profile.validation";
-import { validateSignUp } from "../vaildataions/auth.validation";
 
 const profileRouter = express.Router();
 
+// 일반 유저가 프로필 생성
 profileRouter.post(
   "/customer",
   authenticatedOnly,
@@ -23,6 +23,7 @@ profileRouter.post(
   profile.createCustomerProfileController
 );
 
+// 기사사 유저가 프로필 생성
 profileRouter.post(
   "/worker",
   authenticatedOnly,
@@ -32,6 +33,7 @@ profileRouter.post(
   profile.createWorkerProfileController
 );
 
+// 일반 유저가 프로필 수정
 profileRouter.put(
   "/customer",
   authenticatedOnly,
@@ -41,6 +43,7 @@ profileRouter.put(
   profile.updateCustomerProfileController
 );
 
+// 기사사 유저가 프로필 수정
 profileRouter.put(
   "/worker",
   authenticatedOnly,

--- a/src/routes/profile.route.ts
+++ b/src/routes/profile.route.ts
@@ -53,4 +53,16 @@ profileRouter.put(
   profile.updateWorkerProfileController
 );
 
+profileRouter.get(
+  "/worker/:workerId",
+  authenticatedOnly,
+  profile.getWorkerProfileController
+);
+
+// profileRouter.get(
+//   "/customer/:customerId",
+//   authenticatedOnly,
+//   profile.getCustomerProfileController
+// );
+
 export default profileRouter;

--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -5,7 +5,10 @@ import { validateUpdateUserInfo } from "../vaildataions/auth.validation";
 
 const userRouter = express.Router();
 
+// 내 정보 가져오기 , 프로필 이미지, 이름, 프로필 생성 여부
 userRouter.get("/me", authenticatedOnly, user.getUserMeController);
+
+// 내 정보 수정하기 , 이메일,이름,전화번호,비밀번호 수정
 userRouter.put(
   "/",
   authenticatedOnly,

--- a/src/servieces/auth.service.ts
+++ b/src/servieces/auth.service.ts
@@ -9,6 +9,7 @@ if (!jwtSecretKey) {
   throw new Error("jwtSerectKey is not exist");
 }
 
+// 토큰 생성 함수
 const createToken = (data: PayloadData) => {
   try {
     const payload = {
@@ -33,6 +34,7 @@ const createToken = (data: PayloadData) => {
   }
 };
 
+// 비밀번호가 암호화된(DB에 저장된) 비밀번호와 같은지 확인하는 함수
 export const checkPassword = async (
   password: string,
   encryptedPassword: string
@@ -47,6 +49,7 @@ export const checkPassword = async (
   }
 };
 
+// 로그인 함수
 const logIn = async (logInDto: LogInDto) => {
   try {
     const result = await prisma.$transaction(async (prisma) => {
@@ -83,6 +86,7 @@ const logIn = async (logInDto: LogInDto) => {
   }
 };
 
+// 회원가입 함수
 const signUp = async (signUpDto: SignUpDto) => {
   try {
     const { email, password, name, phoneNumber, role } = signUpDto;
@@ -117,6 +121,7 @@ const signUp = async (signUpDto: SignUpDto) => {
   }
 };
 
+// 리프레쉬 토큰 함수
 const refreshToken = async (refreshToken: string) => {
   const { sub, email, name } = jwt.verify(
     refreshToken,

--- a/src/servieces/estimate-request.sevice.ts
+++ b/src/servieces/estimate-request.sevice.ts
@@ -1,6 +1,8 @@
 import prisma from "../db/prisma/client";
 import { EstimateRequstDto } from "../types/estimate-request.type";
+import { findActiveEstimateRequest } from "./utills";
 
+// 견적 요청 생성 함수
 const createEstimateRequest = async (estimateRequstDto: EstimateRequstDto) => {
   try {
     const { customerId } = estimateRequstDto;
@@ -21,6 +23,7 @@ const createEstimateRequest = async (estimateRequstDto: EstimateRequstDto) => {
   }
 };
 
+// 견적 요청 삭제 함수
 const deleteEstimateRequest = async (customerId: string) => {
   try {
     const estimateRequest = await prisma.estimateRequest.findFirst({
@@ -43,6 +46,19 @@ const deleteEstimateRequest = async (customerId: string) => {
   }
 };
 
-const estimateRequstService = { createEstimateRequest, deleteEstimateRequest };
+// 견적 요청의 상태를 confirm으로 변경하는함수
+const confirmEstimateRequest = async (customerId: string) => {
+  const { id: estimateRequestId } = await findActiveEstimateRequest(customerId);
+  await prisma.estimateRequest.update({
+    where: { id: estimateRequestId },
+    data: { status: "confirmed" },
+  });
+};
+
+const estimateRequstService = {
+  createEstimateRequest,
+  deleteEstimateRequest,
+  confirmEstimateRequest,
+};
 
 export default estimateRequstService;

--- a/src/servieces/estimate.service.ts
+++ b/src/servieces/estimate.service.ts
@@ -1,0 +1,103 @@
+import { EstimateStatus } from "@prisma/client";
+import prisma from "../db/prisma/client";
+import { findActiveEstimateRequest, findEstimate, findUser } from "./utills";
+
+// 견적 생성 함수
+const createEstimate = async (
+  workerId: string,
+  customerId: string,
+  status: EstimateStatus,
+  price?: number
+) => {
+  try {
+    const estimateRequest = await findActiveEstimateRequest(customerId);
+
+    await findUser(workerId);
+
+    const { id, serviceType, departure, destination, movingDate } =
+      estimateRequest;
+
+    const estimate = await prisma.estimate.findFirst({
+      where: { customerId, workerId },
+    });
+
+    if (estimate) throw new Error("400/estimate already exist");
+
+    if (status === "general" && price === undefined) {
+      throw new Error("400/price is required for general estimate");
+    }
+
+    await prisma.estimate.create({
+      data: {
+        estimateRequestId: id,
+        customerId,
+        workerId,
+        serviceType,
+        departure,
+        destination,
+        movingDate,
+        status,
+        ...(status === "general" ? { price } : {}),
+      },
+    });
+  } catch (e) {
+    throw e;
+  }
+};
+
+// 견적의 isCompleted: ture로 변경, 만약 가격이 없으면 에러 반환
+const confirmEstimate = async (estimateId: string) => {
+  try {
+    const { price } = await findEstimate(estimateId);
+    if (!price) throw new Error("400/The estimate is not yet priced");
+    await prisma.estimate.update({
+      where: { id: estimateId },
+      data: { isCompleted: true },
+    });
+  } catch (e) {
+    throw e;
+  }
+};
+//
+const rejectEstimate = async (estimateId: string, rejectionMessage: string) => {
+  try {
+    // 견적이 있는지 확인
+    const { price } = await findEstimate(estimateId, "assigned");
+    if (price) throw new Error("400/estimate already sent to the user.");
+    await prisma.estimate.update({
+      where: { id: estimateId },
+      data: { status: "rejected", rejectionMessage },
+    });
+  } catch (e) {
+    throw e;
+  }
+};
+//
+const priceEstimate = async (
+  estimateId: string,
+  price: number,
+  comment: string
+) => {
+  try {
+    // 견적이 있는지 확인(거부된거면 가격 못하게)
+    if (!price) throw new Error("400/price is required for general estimate");
+    const { price: checkPrice } = await findEstimate(estimateId, "assigned");
+    if (checkPrice) throw new Error("400/estimate already sent to the user.");
+
+    await prisma.estimate.update({
+      where: { id: estimateId },
+      data: { price, comment },
+    });
+  } catch (e) {
+    throw e;
+  }
+};
+
+const estimateService = {
+  createEstimate,
+  confirmEstimate,
+  rejectEstimate,
+  priceEstimate,
+};
+
+export default estimateService;

--- a/src/servieces/estimate.service.ts
+++ b/src/servieces/estimate.service.ts
@@ -45,14 +45,14 @@ const createEstimate = async (
   }
 };
 
-// 견적의 isCompleted: ture로 변경, 만약 가격이 없으면 에러 반환
+// 견적의 isConfirmed: ture로 변경, 만약 가격이 없으면 에러 반환
 const confirmEstimate = async (estimateId: string) => {
   try {
     const { price } = await findEstimate(estimateId);
     if (!price) throw new Error("400/The estimate is not yet priced");
     await prisma.estimate.update({
       where: { id: estimateId },
-      data: { isCompleted: true },
+      data: { isConfirmed: true },
     });
   } catch (e) {
     throw e;
@@ -93,11 +93,100 @@ const priceEstimate = async (
   }
 };
 
+//pending 상태의 견적들 찾기기
+const getPendingEstimates = async (customerId: string) => {
+  try {
+    // 아이디 찾기
+    const { id: estimateRequestId } = await findActiveEstimateRequest(
+      customerId
+    );
+    const pendingEstimate = await prisma.estimate.findMany({
+      where: { estimateRequestId },
+    });
+    return pendingEstimate;
+  } catch (e) {
+    throw e;
+  }
+};
+
+//estimateRequestId에 해당하는 견적들 찾기
+const getEstimatesByEstimateRequestId = async (estimateRequestId: string) => {
+  try {
+    const estimates = await prisma.estimate.findMany({
+      where: { estimateRequestId },
+    });
+    return estimates;
+  } catch (e) {
+    throw e;
+  }
+};
+
+const getEstimateByEstimatetId = async (estimatetId: string) => {
+  try {
+    const estimate = await prisma.estimate.findFirst({
+      where: { id: estimatetId },
+    });
+    if (!estimate) throw new Error("400/Estimate not found");
+    return estimate;
+  } catch (e) {
+    throw e;
+  }
+};
+
+const getAssignedEstimate = async (workerId: string, isConfirmed?: boolean) => {
+  try {
+    const where: any = {
+      workerId,
+      status: "assigned",
+    };
+    if (typeof isConfirmed === "boolean") {
+      where.isConfirmed = isConfirmed;
+    }
+    const estimates = await prisma.estimate.findMany({
+      where,
+    });
+    if (!estimates) throw new Error("400/estimates not found");
+    return estimates;
+  } catch (e) {
+    throw e;
+  }
+};
+
+const getSentEstimates = async (workerId: string) => {
+  try {
+    const estimates = await prisma.estimate.findMany({
+      where: { workerId },
+    });
+    if (!estimates) throw new Error("400/estimates not found");
+    return estimates;
+  } catch (e) {
+    throw e;
+  }
+};
+
+const getRejectEstimates = async (workerId: string) => {
+  try {
+    const estimates = await prisma.estimate.findMany({
+      where: { workerId, status: "rejected" },
+    });
+    if (!estimates) throw new Error("400/estimates not found");
+    return estimates;
+  } catch (e) {
+    throw e;
+  }
+};
+
 const estimateService = {
   createEstimate,
   confirmEstimate,
   rejectEstimate,
   priceEstimate,
+  getPendingEstimates,
+  getEstimatesByEstimateRequestId,
+  getEstimateByEstimatetId,
+  getAssignedEstimate,
+  getSentEstimates,
+  getRejectEstimates,
 };
 
 export default estimateService;

--- a/src/servieces/profile.service.ts
+++ b/src/servieces/profile.service.ts
@@ -24,6 +24,7 @@ const createCustomerProfile = async (
     throw e;
   }
 };
+
 // 기사 프로필 생성
 const createWorkerProfile = async (workerProfileDto: WorkerProfileDto) => {
   try {
@@ -45,6 +46,7 @@ const createWorkerProfile = async (workerProfileDto: WorkerProfileDto) => {
     throw e;
   }
 };
+
 // 프로필 상태 업데이트 - 유저가 프로필을 만들었는지 확인해서 true/false 값 반환
 const updateUserProfileStatus = async (userId: string) => {
   try {

--- a/src/servieces/profile.service.ts
+++ b/src/servieces/profile.service.ts
@@ -112,12 +112,39 @@ const updateWorkerProfile = async (
   }
 };
 
+// 기사 유저의 profile 가져오기
+const getWorkerProfile = async (workerId: string) => {
+  try {
+    const workerProfile = await prisma.workerProfile.findFirst({
+      where: { workerId },
+    });
+    if (!workerProfile) throw new Error("400/worker profile not exist");
+    return workerProfile;
+  } catch (e) {
+    throw e;
+  }
+};
+
+// // 일반 유저의 profile 가져오기
+// const getCustomerProfile = async (customerId: string) => {
+//   try {
+//     const customerProfile = await prisma.customerProfile.findFirst({
+//       where: { customerId },
+//     });
+//     if (!customerProfile) throw new Error("400/worker profile not exist");
+//     return customerProfile;
+//   } catch (e) {
+//     throw e;
+//   }
+// };
+
 const profileService = {
   createCustomerProfile,
   createWorkerProfile,
   updateUserProfileStatus,
   updateCustomerProfile,
   updateWorkerProfile,
+  getWorkerProfile,
 };
 
 export default profileService;

--- a/src/servieces/user.service.ts
+++ b/src/servieces/user.service.ts
@@ -1,3 +1,4 @@
+import user from "../controllers/user.controller";
 import prisma from "../db/prisma/client";
 import { UpdateUserDto } from "../types/auth.type";
 import { checkPassword } from "./auth.service";
@@ -5,6 +6,7 @@ import bcrypt from "bcrypt";
 
 const BASE_URL = "http://localhost:5050";
 
+// 내정보 가져오는 함수 : 이름 , 프로필 생성 여부
 const getUserMe = async (userId: string) => {
   try {
     const user = await prisma.user.findFirst({ where: { id: userId } });
@@ -20,6 +22,7 @@ const getUserMe = async (userId: string) => {
   }
 };
 
+// 내정보 가져오는 함수 : 프로필 이미지 가져오는 함수
 const getProfileImage = async (userId: string) => {
   try {
     // 유저인 경우
@@ -51,7 +54,7 @@ const getProfileImage = async (userId: string) => {
   }
 };
 
-//유저 정보 업데이트, 기존의 signup validation을 사용하기, + 새비밀번호의 데이터가 올바른지 확인하기
+//유저 정보 업데이트하는 함수
 const updateUserInfo = async (updateUserDto: UpdateUserDto) => {
   try {
     const { userId, password, newPassword, ...rest } = updateUserDto;

--- a/src/servieces/utills.ts
+++ b/src/servieces/utills.ts
@@ -1,0 +1,52 @@
+import { EstimateStatus } from "@prisma/client";
+import prisma from "../db/prisma/client";
+
+// 유저가 존재하는지 찾기
+export const findUser = async (userId: string) => {
+  try {
+    await prisma.user.findFirst({
+      where: { id: userId },
+      select: { id: true },
+    });
+    if (!userId) throw new Error("400/worker not found");
+  } catch (e) {
+    throw e;
+  }
+};
+
+// 기사-유저간의 존재하는 활성 견적 요청 가져오기 함수
+export const findActiveEstimateRequest = async (customerId: string) => {
+  try {
+    const estimateRequest = await prisma.estimateRequest.findFirst({
+      where: { customerId, status: "active" },
+    });
+    if (!estimateRequest)
+      throw new Error("400/acitve Estimate Request not found");
+
+    return estimateRequest;
+  } catch (e) {
+    throw e;
+  }
+};
+
+// 기사-유저간의 존재하는 견적 가져오기 함수
+export const findEstimate = async (
+  estimateId: string,
+  status?: EstimateStatus
+) => {
+  try {
+    const where: any = { id: estimateId };
+    if (status) {
+      where.status = status;
+    }
+    const estimate = await prisma.estimate.findFirst({
+      where,
+    });
+    if (!estimate)
+      throw new Error(`400/${status ? status : ""} Estimate not found`);
+
+    return estimate;
+  } catch (e) {
+    throw e;
+  }
+};

--- a/src/servieces/utills.ts
+++ b/src/servieces/utills.ts
@@ -29,6 +29,34 @@ export const findActiveEstimateRequest = async (customerId: string) => {
   }
 };
 
+export const findInactiveEstimateRequests = async (customerId: string) => {
+  try {
+    const estimateRequest = await prisma.estimateRequest.findMany({
+      where: { customerId, status: "inactive" },
+    });
+    if (!estimateRequest)
+      throw new Error("400/acitve Estimate Request not found");
+
+    return estimateRequest;
+  } catch (e) {
+    throw e;
+  }
+};
+
+export const findActiveEstimateRequests = async () => {
+  try {
+    const estimateRequest = await prisma.estimateRequest.findMany({
+      where: { status: "active" },
+    });
+    if (!estimateRequest)
+      throw new Error("400/acitve Estimate Request not found");
+
+    return estimateRequest;
+  } catch (e) {
+    throw e;
+  }
+};
+
 // 기사-유저간의 존재하는 견적 가져오기 함수
 export const findEstimate = async (
   estimateId: string,


### PR DESCRIPTION
## 일반유저
- 지정 견적 생성하기
/estimate/assinged/:workId
활성 견적 요청이 없으면 에러가 납니다.
기사ID 가 올바르지 않으면 에러가 납니다.
- 견적 확정하기
/estimate/confirm/:estimateId
견적 Id에 해당하는 견적을 확정합니다. isCompleted->ture로 변경
견적요청의 status를 confirm으로 변경합니다.

### 추가구현 (기사님 프로필은 다른 라우터를 통해서 구할수 있도록 구현했습니다.) 
- 대기중인 견적 조회하기+ 4/7 기사 프로필 리턴값에 추가
/estimate/pending
- 견적요청들 조회하기 (활성견적들 제외)
/estimate-request/
- 받았던 견적 조회하기 + 4/7 기사 프로필 리턴값에 추가
/estimate/received/:estimateRequestId

## 기사유저
- 일반 견적 생성하기
/estimate/general/:customerId
활성 견적 요청이 없으면 에러가 납니다.
고객ID 가 올바르지 않으면 에러가 납니다.

- 지정 견적 업데이트 → 반려 or 견적보내기(견적 금액 추가하기)
1. 반려
 /estimate/reject/:estimateId
 -  지정 견적만 반려로 상태 업데이트 할 수 있습니다.
 -  가격이 이미 측정된 견적은 반려할 수 없습니다.
 - body :{"rejectionMessage":"반려!"} 필수 아님
2. 견적보내기
/estimate/price/:estimateId
 - 지정 견적만 금액을 추가할 수 있습니다.
 - 가격을 측정해서 견적을 보내면, 다시 수정할 수 없습니다
 - {"price":40000, "comment":"코멘트"} 가격만 필수, 코멘트는 필수 아님
 
### 추가구현 (유저 이름은 다른 라우터로 얻을수 있도록 할 예정입니다.) + 4/7 유저이름 리턴값에 추가
- 받은 요청 조회하기 -> 필터 기능 미구현 이거는 계속 이어서 구현할 예정입니다.
/estimate-request/received
- 보낸 요청 조회하기 
/estimate/sent
- 반려한 요청 조회하기
/estimate/reject


### 공통 상세 견적 조회하기
/estimate/detail/:estimateId