### PR TITLE
[엄성민] faet:로그인 처리 방식 수정

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -18,6 +18,15 @@ const logInController: RequestHandler = asyncHandler(async (req, res, next) => {
     path: "/",
     maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
   });
+
+  res.cookie("accessToken", accessToken, {
+    httpOnly: true,
+    // secure: process.env.NODE_ENV === "production",
+    secure: false,
+    sameSite: "strict",
+    path: "/",
+    maxAge: 1000 * 60 * 60, // 1시간
+  });
   // sameSite:none secure:ture
   // 백엔드랑 프론트엔드 ip
   // secure:ture -> https // http
@@ -44,7 +53,7 @@ const refreshTokenController: RequestHandler = asyncHandler(
     const refreshToken = req.cookies.refreshToken;
     if (!refreshToken) throw new Error("401/No refresh token");
 
-    const accessToken = await authService.refreshToken(refreshToken);
+    const { accessToken } = await authService.refreshToken(refreshToken);
 
     res.status(200).send({ accessToken });
   }

--- a/src/controllers/estimate-request.controller.ts
+++ b/src/controllers/estimate-request.controller.ts
@@ -26,11 +26,19 @@ const createEstimateRequestController: RequestHandler = asyncHandler(
     await estimateRequstService.createEstimateRequest(estimateRequstDto);
     const { accessToken, refreshToken } =
       await userService.updateUserRequestStatus(customerId);
+
     res.cookie("refreshToken", refreshToken, {
       httpOnly: true,
       secure: false,
       sameSite: "strict",
       maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
+    });
+    res.cookie("accessToken", accessToken, {
+      httpOnly: true,
+      secure: false,
+      sameSite: "strict",
+      path: "/",
+      maxAge: 1000 * 60 * 60, // 1시간
     });
 
     res.status(200).send({ accessToken });

--- a/src/controllers/profile.controller.ts
+++ b/src/controllers/profile.controller.ts
@@ -29,10 +29,16 @@ const createCustomerProfileController: RequestHandler = asyncHandler(
 
     res.cookie("refreshToken", refreshToken, {
       httpOnly: true,
-      // secure: process.env.NODE_ENV === "production",
       secure: false,
       sameSite: "strict",
       maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
+    });
+    res.cookie("accessToken", accessToken, {
+      httpOnly: true,
+      secure: false,
+      sameSite: "strict",
+      path: "/",
+      maxAge: 1000 * 60 * 60, // 1시간
     });
 
     res.status(200).send({ accessToken });
@@ -76,10 +82,17 @@ const createWorkerProfileController: RequestHandler = asyncHandler(
 
     res.cookie("refreshToken", refreshToken, {
       httpOnly: true,
-      // secure: process.env.NODE_ENV === "production",
       secure: false,
       sameSite: "strict",
       maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
+    });
+
+    res.cookie("accessToken", accessToken, {
+      httpOnly: true,
+      secure: false,
+      sameSite: "strict",
+      path: "/",
+      maxAge: 1000 * 60 * 60, // 1시간
     });
 
     res.status(200).send({ accessToken });

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -20,8 +20,15 @@ const authMiddleware: RequestHandler = (req, res, next) => {
       throw new Error("401/JWT_SECRET is not defined in environment variables");
     }
 
+    // 쿠키로 오는경우
+    if (cookieToken) {
+      const payload = jwt.verify(cookieToken, jwtSecretKey) as { sub: string };
+      console.log("쿠키로 토큰이 왔습니다!");
+      req.userId = payload.sub;
+    }
+
     //헤더로 오는경우
-    if (headerToken) {
+    else if (headerToken) {
       const accessToken = headerToken.split("Bearer ")[1];
       const { sub } = jwt.verify(accessToken, jwtSecretKey);
 
@@ -30,12 +37,6 @@ const authMiddleware: RequestHandler = (req, res, next) => {
       }
       console.log("헤더로 토큰이 왔습니다!");
       req.userId = sub;
-    }
-    // 쿠키로 오는경우
-    if (cookieToken) {
-      const payload = jwt.verify(cookieToken, jwtSecretKey) as { sub: string };
-      console.log("쿠키로 토큰이 왔습니다!");
-      req.userId = payload.sub;
     }
 
     next();

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -13,22 +13,15 @@ const authMiddleware: RequestHandler = (req, res, next) => {
     if (req.url === "/auth/sign-up" || req.url === "/auth/log-in")
       return next();
 
-    const headerToken = req.headers.authorization;
-    const cookieToken = req.cookies.refreshToken;
-
     if (!jwtSecretKey) {
       throw new Error("401/JWT_SECRET is not defined in environment variables");
     }
 
-    // 쿠키로 오는경우
-    if (cookieToken) {
-      const payload = jwt.verify(cookieToken, jwtSecretKey) as { sub: string };
-      console.log("쿠키로 토큰이 왔습니다!");
-      req.userId = payload.sub;
-    }
+    const headerToken = req.headers.authorization;
+    const cookieToken = req.cookies.accessToken;
 
     //헤더로 오는경우
-    else if (headerToken) {
+    if (headerToken) {
       const accessToken = headerToken.split("Bearer ")[1];
       const { sub } = jwt.verify(accessToken, jwtSecretKey);
 
@@ -37,6 +30,12 @@ const authMiddleware: RequestHandler = (req, res, next) => {
       }
       console.log("헤더로 토큰이 왔습니다!");
       req.userId = sub;
+    }
+    // 쿠키로 오는경우
+    else if (cookieToken) {
+      const payload = jwt.verify(cookieToken, jwtSecretKey) as { sub: string };
+      console.log("쿠키로 토큰이 왔습니다!");
+      req.userId = payload.sub;
     }
 
     next();

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -12,22 +12,31 @@ const authMiddleware: RequestHandler = (req, res, next) => {
   try {
     if (req.url === "/auth/sign-up" || req.url === "/auth/log-in")
       return next();
-    const token = req.headers.authorization;
-    if (!token) {
-      return next();
-    }
 
-    const accessToken = token.split("Bearer ")[1];
+    const headerToken = req.headers.authorization;
+    const cookieToken = req.cookies.refreshToken;
+
     if (!jwtSecretKey) {
       throw new Error("401/JWT_SECRET is not defined in environment variables");
     }
-    const { sub } = jwt.verify(accessToken, jwtSecretKey);
 
-    if (typeof sub !== "string") {
-      throw new Error("400/sub is not string");
+    //헤더로 오는경우
+    if (headerToken) {
+      const accessToken = headerToken.split("Bearer ")[1];
+      const { sub } = jwt.verify(accessToken, jwtSecretKey);
+
+      if (typeof sub !== "string") {
+        throw new Error("400/sub is not string");
+      }
+      console.log("헤더로 토큰이 왔습니다!");
+      req.userId = sub;
     }
-
-    req.userId = sub;
+    // 쿠키로 오는경우
+    if (cookieToken) {
+      const payload = jwt.verify(cookieToken, jwtSecretKey) as { sub: string };
+      console.log("쿠키로 토큰이 왔습니다!");
+      req.userId = payload.sub;
+    }
 
     next();
   } catch (e) {


### PR DESCRIPTION
- access토큰도 header에서 쿠키로 변경 
- 현재는 임시로 헤더와 토큰 모두 받을 수 있도록 구현  : 헤더 쿠키 둘다 보낼경우 헤더로 인식함.