### PR TITLE
[조형민] 사용자 세션 하이재킹 공격 방어를 위한 보안용 CSRF 토큰 탑재 - state 검증

### DIFF
--- a/src/controllers/google.controller.ts
+++ b/src/controllers/google.controller.ts
@@ -1,4 +1,5 @@
 // src/controllers/google.controller.ts
+import { ROLE } from '@prisma/client';
 import { RequestHandler } from 'express';
 import authService from '../services/auth.service';
 import {
@@ -6,20 +7,35 @@ import {
   getGoogleAuthURL,
   getGoogleUser,
 } from '../services/google.service';
-import { decodeState, encodeState } from '../utils/oauth/oauthState';
 
 const googleLoginRedirect: RequestHandler = (req, res) => {
-  const { role } = req.query; // 회원 구분을 위한 role 추가
-  const state = encodeState({ role }); // 안전하게 인코딩
-  const url = getGoogleAuthURL(state);
+  const state = req.query.state as string; // csrfToken, role포함
+  const [csrfToken] = state.split('|');
+  // 백엔드 도메인 기준 쿠키 저장(googleCallback에서 검증할 때 사용)
+  res.cookie('oauth_csrf_token', csrfToken, {
+    httpOnly: true,
+    secure: false,
+    sameSite: 'lax', // !!! strict로 하면 실패했음(외부 리다이렉트 흐름에서는 안 붙는다고?!?!)
+    path: '/',
+    maxAge: 5 * 60 * 1000,
+  });
+
+  const url = getGoogleAuthURL(state); // 구글 로그인 URL로 그대로 전달
   res.redirect(url);
 };
 
 const googleCallback: RequestHandler = async (req, res, next) => {
   try {
     const code = req.query.code as string;
-    const state = req.query.state as string;
-    const { role } = decodeState(state); // role 정보를 받아서 디코딩
+    const state = req.query.state as string; // csrfToken, role포함
+    const [csrfTokenFromState, roleFromState] = state.split('|');
+    const csrfTokenStored = req.cookies['oauth_csrf_token'];
+
+    if (!csrfTokenFromState || csrfTokenFromState !== csrfTokenStored) {
+      return res.redirect(
+        'http://localhost:3000/auth/callback?errorCode=INVALID_OAUTH_STATE'
+      );
+    }
     const { id_token, access_token } = await exchangeCodeForToken(code);
     const googleUser = await getGoogleUser(id_token, access_token);
 
@@ -28,7 +44,7 @@ const googleCallback: RequestHandler = async (req, res, next) => {
       name: googleUser.name,
       profileImage: googleUser.picture,
       provider: 'google',
-      role,
+      role: roleFromState as ROLE,
     });
 
     const { accessToken, refreshToken } =

--- a/src/controllers/kakao.controller.ts
+++ b/src/controllers/kakao.controller.ts
@@ -1,3 +1,4 @@
+import { ROLE } from '@prisma/client';
 import { RequestHandler } from 'express';
 import authService from '../services/auth.service';
 import {
@@ -5,11 +6,20 @@ import {
   getKakaoAuthURL,
   getKakaoUser,
 } from '../services/kakao.service';
-import { decodeState, encodeState } from '../utils/oauth/oauthState';
 
 const kakaoLoginRedirect: RequestHandler = (req, res) => {
-  const { role } = req.query;
-  const state = encodeState({ role });
+  const state = req.query.state as string; // csrfToken, role 포함
+  const [csrfToken] = state.split('|');
+
+  // 백엔드 도메인 기준 쿠키 저장 (콜백에서 검증용)
+  res.cookie('oauth_csrf_token', csrfToken, {
+    httpOnly: true,
+    secure: false,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 5 * 60 * 1000,
+  });
+
   const url = getKakaoAuthURL(state);
   res.redirect(url);
 };
@@ -18,7 +28,14 @@ const kakaoCallback: RequestHandler = async (req, res) => {
   try {
     const code = req.query.code as string;
     const state = req.query.state as string;
-    const { role } = decodeState(state);
+    const [csrfTokenFromState, roleFromState] = state.split('|');
+    const csrfTokenStored = req.cookies['oauth_csrf_token'];
+
+    if (!csrfTokenFromState || csrfTokenFromState !== csrfTokenStored) {
+      return res.redirect(
+        'http://localhost:3000/auth/callback?errorCode=INVALID_OAUTH_STATE'
+      );
+    }
 
     const { access_token } = await exchangeCodeForToken(code);
     const kakaoProfile = await getKakaoUser(access_token);
@@ -33,7 +50,7 @@ const kakaoCallback: RequestHandler = async (req, res) => {
       name,
       profileImage,
       provider: 'kakao',
-      role,
+      role: roleFromState as ROLE,
     });
 
     const { accessToken, refreshToken } =
@@ -57,7 +74,6 @@ const kakaoCallback: RequestHandler = async (req, res) => {
 
     res.redirect('http://localhost:3000/auth/callback');
   } catch (e) {
-    // 에러 발생 시 프론트로 메시지 전달
     if (typeof e === 'object' && e && 'errorCode' in e) {
       const { errorCode, data } = e as {
         errorCode: string;
@@ -68,11 +84,13 @@ const kakaoCallback: RequestHandler = async (req, res) => {
       return res.redirect(`http://localhost:3000/auth/callback?${query}`);
     }
 
-    // 예상치 못한 에러
     return res.redirect(
       `http://localhost:3000/auth/callback?errorCode=UNKNOWN_ERROR`
     );
   }
 };
 
-export default { kakaoLoginRedirect, kakaoCallback };
+export default {
+  kakaoLoginRedirect,
+  kakaoCallback,
+};

--- a/src/controllers/naver.controller.ts
+++ b/src/controllers/naver.controller.ts
@@ -1,3 +1,4 @@
+import { ROLE } from '@prisma/client';
 import { RequestHandler } from 'express';
 import authService from '../services/auth.service';
 import {
@@ -5,11 +6,19 @@ import {
   getNaverAuthURL,
   getNaverUser,
 } from '../services/naver.service';
-import { decodeState, encodeState } from '../utils/oauth/oauthState';
 
 const naverLoginRedirect: RequestHandler = (req, res) => {
-  const { role } = req.query;
-  const state = encodeState({ role });
+  const state = req.query.state as string; // csrfToken, role 포함
+  const [csrfToken] = state.split('|');
+
+  res.cookie('oauth_csrf_token', csrfToken, {
+    httpOnly: true,
+    secure: false,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 5 * 60 * 1000,
+  });
+
   const url = getNaverAuthURL(state);
   res.redirect(url);
 };
@@ -18,7 +27,14 @@ const naverCallback: RequestHandler = async (req, res) => {
   try {
     const code = req.query.code as string;
     const state = req.query.state as string;
-    const { role } = decodeState(state);
+    const [csrfTokenFromState, roleFromState] = state.split('|');
+    const csrfTokenStored = req.cookies['oauth_csrf_token'];
+
+    if (!csrfTokenFromState || csrfTokenFromState !== csrfTokenStored) {
+      return res.redirect(
+        'http://localhost:3000/auth/callback?errorCode=INVALID_OAUTH_STATE'
+      );
+    }
 
     const { access_token } = await exchangeCodeForToken(code, state);
     const naverUser = await getNaverUser(access_token);
@@ -28,7 +44,7 @@ const naverCallback: RequestHandler = async (req, res) => {
       name: naverUser.name,
       profileImage: naverUser.profile_image,
       provider: 'naver',
-      role,
+      role: roleFromState as ROLE,
     });
 
     const { accessToken, refreshToken } =

--- a/src/utils/oauth/oauthState.ts
+++ b/src/utils/oauth/oauthState.ts
@@ -1,6 +1,18 @@
-// 소셜 로그인 시 state로 전달하는 role정보를 안전하게 encode/decode하기 위한 유틸 함수
-export const encodeState = (data: any): string =>
-  Buffer.from(JSON.stringify(data)).toString('base64url');
+// 소셜 로그인 시 state로 전달하는 state(role, csrfToken)정보를 안전하게 encode/decode하기 위한 유틸 함수
+export function encodeState({
+  role,
+  csrfToken,
+}: {
+  role: string;
+  csrfToken: string;
+}) {
+  return Buffer.from(JSON.stringify({ role, csrfToken })).toString('base64');
+}
 
-export const decodeState = (state: string): any =>
-  JSON.parse(Buffer.from(state, 'base64url').toString('utf-8'));
+export function decodeState(state: string): {
+  role: string;
+  csrfToken: string;
+} {
+  const decoded = Buffer.from(state, 'base64').toString();
+  return JSON.parse(decoded);
+}


### PR DESCRIPTION
### 문제
- OAuth의 응답 code를 이용한 CSRF 공격을 방어할 필요가 있음

### 해결
- 프론트엔드
    - role뿐만 아니라 csrfToken을 생성하여 state로 함께 전달
        
        ```tsx
        const csrfToken = crypto.randomUUID(); // 보안용
        const state = `${csrfToken}|${role}`;
        ```
        
- 백엔드
    - 받은 state에서 csrfToken을 꺼내 백엔드 도메인 쿠키에 저장
    - state를 redirect URL에 전달하고 소셜 로그인 성공 시 callback으로 다시 받음
    - callback의 state에서 꺼낸 csrfToken과 백엔드 쿠키의 csrfToken을 비교하여 검증