### PR TITLE
[조형민] 소셜 로그인 관련 코드 리팩터링

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,8 +5,8 @@ import express from 'express';
 import { errorHandler } from './middleware/error.middleware';
 import router from './routes';
 
-// export const BASE_URL = 'http://localhost:5050';
-export const BASE_URL = 'http://54.180.2.174';
+export const BASE_URL = 'http://localhost:5050';
+// export const BASE_URL = 'http://54.180.2.174';
 
 const app = express();
 const port = 5050;
@@ -25,8 +25,8 @@ app.use(router);
 app.use(errorHandler);
 
 app.listen(port, () => {
-  // console.log(`Server running http://localhost:5050`);
-  console.log(
-    `ci/cd 업데이트 완료! Server running at http://54.180.2.174 prisma: http://54.180.2.174:5555`
-  );
+  console.log(`Server running http://localhost:5050`);
+  // console.log(
+  //   `ci/cd 업데이트 완료! Server running at http://54.180.2.174 prisma: http://54.180.2.174:5555`
+  // );
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,8 +5,8 @@ import express from 'express';
 import { errorHandler } from './middleware/error.middleware';
 import router from './routes';
 
-export const BASE_URL = 'http://localhost:5050';
-// export const BASE_URL = 'http://54.180.2.174';
+// export const BASE_URL = 'http://localhost:5050';
+export const BASE_URL = 'http://54.180.2.174';
 
 const app = express();
 const port = 5050;
@@ -25,8 +25,8 @@ app.use(router);
 app.use(errorHandler);
 
 app.listen(port, () => {
-  console.log(`Server running http://localhost:5050`);
-  // console.log(
-  //   `ci/cd 업데이트 완료! Server running at http://54.180.2.174 prisma: http://54.180.2.174:5555`
-  // );
+  // console.log(`Server running http://localhost:5050`);
+  console.log(
+    `ci/cd 업데이트 완료! Server running at http://54.180.2.174 prisma: http://54.180.2.174:5555`
+  );
 });

--- a/src/controllers/google.controller.ts
+++ b/src/controllers/google.controller.ts
@@ -1,92 +1,31 @@
-// src/controllers/google.controller.ts
-import { ROLE } from '@prisma/client';
 import { RequestHandler } from 'express';
-import authService from '../services/auth.service';
 import {
   exchangeCodeForToken,
   getGoogleAuthURL,
   getGoogleUser,
 } from '../services/google.service';
+import {
+  handleOAuthCallback,
+  handleOAuthRedirect,
+} from '../services/oauth.service';
 
 const googleLoginRedirect: RequestHandler = (req, res) => {
-  const state = req.query.state as string; // csrfToken, role포함
-  const [csrfToken] = state.split('|');
-  // 백엔드 도메인 기준 쿠키 저장(googleCallback에서 검증할 때 사용)
-  res.cookie('oauth_csrf_token', csrfToken, {
-    httpOnly: true,
-    secure: false,
-    sameSite: 'lax', // !!! strict로 하면 실패했음(외부 리다이렉트 흐름에서는 안 붙는다고?!?!)
-    path: '/',
-    maxAge: 5 * 60 * 1000,
-  });
-
-  const url = getGoogleAuthURL(state); // 구글 로그인 URL로 그대로 전달
-  res.redirect(url);
+  const state = req.query.state as string; // csrfToken, role 포함
+  handleOAuthRedirect(state, getGoogleAuthURL, res);
 };
 
-const googleCallback: RequestHandler = async (req, res, next) => {
-  try {
-    const code = req.query.code as string;
-    const state = req.query.state as string; // csrfToken, role포함
-    const [csrfTokenFromState, roleFromState] = state.split('|');
-    const csrfTokenStored = req.cookies['oauth_csrf_token'];
-
-    if (!csrfTokenFromState || csrfTokenFromState !== csrfTokenStored) {
-      res.clearCookie('oauth_csrf_token', { path: '/' }); // 검증 실패 시에도 삭제
-      return res.redirect(
-        'http://localhost:3000/auth/callback?errorCode=INVALID_OAUTH_STATE'
-      );
-    }
-    const { id_token, access_token } = await exchangeCodeForToken(code);
-    const googleUser = await getGoogleUser(id_token, access_token);
-
-    const user = await authService.findOrCreateOAuthUser({
-      email: googleUser.email,
-      name: googleUser.name,
-      profileImage: googleUser.picture,
-      provider: 'google',
-      role: roleFromState as ROLE,
-    });
-
-    const { accessToken, refreshToken } =
-      authService.createTokenByUserData(user);
-
-    res.cookie('refreshToken', refreshToken, {
-      httpOnly: true,
-      secure: false,
-      sameSite: 'strict',
-      path: '/',
-      maxAge: 1000 * 60 * 60 * 24 * 7,
-    });
-
-    res.cookie('accessToken', accessToken, {
-      httpOnly: true,
-      secure: false,
-      sameSite: 'strict',
-      path: '/',
-      maxAge: 1000 * 60 * 60,
-    });
-
-    res.clearCookie('oauth_csrf_token', { path: '/' }); // 성공 후에도 삭제
-
-    res.redirect('http://localhost:3000/auth/callback'); // 프론트로 이동
-  } catch (e) {
-    // 에러 발생 시 프론트로 메시지 전달
-    if (typeof e === 'object' && e && 'errorCode' in e) {
-      const { errorCode, data } = e as {
-        errorCode: string;
-        data?: Record<string, string>;
-      };
-
-      const query = new URLSearchParams({ errorCode, ...data }).toString();
-      return res.redirect(`http://localhost:3000/auth/callback?${query}`);
-    }
-
-    // 예상치 못한 에러
-    return res.redirect(
-      `http://localhost:3000/auth/callback?errorCode=UNKNOWN_ERROR`
-    );
-  }
+const googleCallback: RequestHandler = async (req, res) => {
+  await handleOAuthCallback(req, res, {
+    name: 'google',
+    exchangeCodeForToken,
+    getUserInfo: ({ id_token, access_token }) =>
+      getGoogleUser(id_token, access_token),
+    mapUser: (user) => ({
+      email: user.email,
+      name: user.name,
+      profileImage: user.picture,
+    }),
+  });
 };
 
 export default {

--- a/src/controllers/google.controller.ts
+++ b/src/controllers/google.controller.ts
@@ -32,6 +32,7 @@ const googleCallback: RequestHandler = async (req, res, next) => {
     const csrfTokenStored = req.cookies['oauth_csrf_token'];
 
     if (!csrfTokenFromState || csrfTokenFromState !== csrfTokenStored) {
+      res.clearCookie('oauth_csrf_token', { path: '/' }); // 검증 실패 시에도 삭제
       return res.redirect(
         'http://localhost:3000/auth/callback?errorCode=INVALID_OAUTH_STATE'
       );
@@ -65,6 +66,8 @@ const googleCallback: RequestHandler = async (req, res, next) => {
       path: '/',
       maxAge: 1000 * 60 * 60,
     });
+
+    res.clearCookie('oauth_csrf_token', { path: '/' }); // 성공 후에도 삭제
 
     res.redirect('http://localhost:3000/auth/callback'); // 프론트로 이동
   } catch (e) {

--- a/src/controllers/kakao.controller.ts
+++ b/src/controllers/kakao.controller.ts
@@ -32,6 +32,7 @@ const kakaoCallback: RequestHandler = async (req, res) => {
     const csrfTokenStored = req.cookies['oauth_csrf_token'];
 
     if (!csrfTokenFromState || csrfTokenFromState !== csrfTokenStored) {
+      res.clearCookie('oauth_csrf_token', { path: '/' }); // 검증 실패 시에도 삭제
       return res.redirect(
         'http://localhost:3000/auth/callback?errorCode=INVALID_OAUTH_STATE'
       );
@@ -71,6 +72,8 @@ const kakaoCallback: RequestHandler = async (req, res) => {
       path: '/',
       maxAge: 1000 * 60 * 60,
     });
+
+    res.clearCookie('oauth_csrf_token', { path: '/' }); // 성공 후에도 삭제
 
     res.redirect('http://localhost:3000/auth/callback');
   } catch (e) {

--- a/src/controllers/kakao.controller.ts
+++ b/src/controllers/kakao.controller.ts
@@ -1,96 +1,30 @@
-import { ROLE } from '@prisma/client';
 import { RequestHandler } from 'express';
-import authService from '../services/auth.service';
 import {
   exchangeCodeForToken,
   getKakaoAuthURL,
   getKakaoUser,
 } from '../services/kakao.service';
+import {
+  handleOAuthCallback,
+  handleOAuthRedirect,
+} from '../services/oauth.service';
 
 const kakaoLoginRedirect: RequestHandler = (req, res) => {
   const state = req.query.state as string; // csrfToken, role 포함
-  const [csrfToken] = state.split('|');
-
-  // 백엔드 도메인 기준 쿠키 저장 (콜백에서 검증용)
-  res.cookie('oauth_csrf_token', csrfToken, {
-    httpOnly: true,
-    secure: false,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 5 * 60 * 1000,
-  });
-
-  const url = getKakaoAuthURL(state);
-  res.redirect(url);
+  handleOAuthRedirect(state, getKakaoAuthURL, res);
 };
 
 const kakaoCallback: RequestHandler = async (req, res) => {
-  try {
-    const code = req.query.code as string;
-    const state = req.query.state as string;
-    const [csrfTokenFromState, roleFromState] = state.split('|');
-    const csrfTokenStored = req.cookies['oauth_csrf_token'];
-
-    if (!csrfTokenFromState || csrfTokenFromState !== csrfTokenStored) {
-      res.clearCookie('oauth_csrf_token', { path: '/' }); // 검증 실패 시에도 삭제
-      return res.redirect(
-        'http://localhost:3000/auth/callback?errorCode=INVALID_OAUTH_STATE'
-      );
-    }
-
-    const { access_token } = await exchangeCodeForToken(code);
-    const kakaoProfile = await getKakaoUser(access_token);
-
-    const kakaoAccount = kakaoProfile.kakao_account;
-    const email = kakaoAccount.email;
-    const name = kakaoAccount.profile.nickname;
-    const profileImage = kakaoAccount.profile.profile_image_url;
-
-    const user = await authService.findOrCreateOAuthUser({
-      email,
-      name,
-      profileImage,
-      provider: 'kakao',
-      role: roleFromState as ROLE,
-    });
-
-    const { accessToken, refreshToken } =
-      authService.createTokenByUserData(user);
-
-    res.cookie('refreshToken', refreshToken, {
-      httpOnly: true,
-      secure: false,
-      sameSite: 'strict',
-      path: '/',
-      maxAge: 1000 * 60 * 60 * 24 * 7,
-    });
-
-    res.cookie('accessToken', accessToken, {
-      httpOnly: true,
-      secure: false,
-      sameSite: 'strict',
-      path: '/',
-      maxAge: 1000 * 60 * 60,
-    });
-
-    res.clearCookie('oauth_csrf_token', { path: '/' }); // 성공 후에도 삭제
-
-    res.redirect('http://localhost:3000/auth/callback');
-  } catch (e) {
-    if (typeof e === 'object' && e && 'errorCode' in e) {
-      const { errorCode, data } = e as {
-        errorCode: string;
-        data?: Record<string, string>;
-      };
-
-      const query = new URLSearchParams({ errorCode, ...data }).toString();
-      return res.redirect(`http://localhost:3000/auth/callback?${query}`);
-    }
-
-    return res.redirect(
-      `http://localhost:3000/auth/callback?errorCode=UNKNOWN_ERROR`
-    );
-  }
+  await handleOAuthCallback(req, res, {
+    name: 'kakao',
+    exchangeCodeForToken,
+    getUserInfo: ({ access_token }) => getKakaoUser(access_token),
+    mapUser: (user) => ({
+      email: user.kakao_account.email,
+      name: user.kakao_account.profile.nickname,
+      profileImage: user.kakao_account.profile.profile_image_url,
+    }),
+  });
 };
 
 export default {

--- a/src/controllers/naver.controller.ts
+++ b/src/controllers/naver.controller.ts
@@ -31,6 +31,7 @@ const naverCallback: RequestHandler = async (req, res) => {
     const csrfTokenStored = req.cookies['oauth_csrf_token'];
 
     if (!csrfTokenFromState || csrfTokenFromState !== csrfTokenStored) {
+      res.clearCookie('oauth_csrf_token', { path: '/' }); // 검증 실패 시에도 삭제
       return res.redirect(
         'http://localhost:3000/auth/callback?errorCode=INVALID_OAUTH_STATE'
       );
@@ -65,6 +66,8 @@ const naverCallback: RequestHandler = async (req, res) => {
       path: '/',
       maxAge: 1000 * 60 * 60,
     });
+
+    res.clearCookie('oauth_csrf_token', { path: '/' }); // 성공 후에도 삭제
 
     res.redirect('http://localhost:3000/auth/callback');
   } catch (e) {

--- a/src/controllers/naver.controller.ts
+++ b/src/controllers/naver.controller.ts
@@ -1,93 +1,29 @@
-import { ROLE } from '@prisma/client';
 import { RequestHandler } from 'express';
-import authService from '../services/auth.service';
 import {
   exchangeCodeForToken,
   getNaverAuthURL,
   getNaverUser,
 } from '../services/naver.service';
+import {
+  handleOAuthCallback,
+  handleOAuthRedirect,
+} from '../services/oauth.service';
 
-const naverLoginRedirect: RequestHandler = (req, res) => {
-  const state = req.query.state as string; // csrfToken, role 포함
-  const [csrfToken] = state.split('|');
-
-  res.cookie('oauth_csrf_token', csrfToken, {
-    httpOnly: true,
-    secure: false,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 5 * 60 * 1000,
-  });
-
-  const url = getNaverAuthURL(state);
-  res.redirect(url);
+export const naverLoginRedirect: RequestHandler = (req, res) => {
+  const state = req.query.state as string;
+  handleOAuthRedirect(state, getNaverAuthURL, res);
 };
 
-const naverCallback: RequestHandler = async (req, res) => {
-  try {
-    const code = req.query.code as string;
-    const state = req.query.state as string;
-    const [csrfTokenFromState, roleFromState] = state.split('|');
-    const csrfTokenStored = req.cookies['oauth_csrf_token'];
-
-    if (!csrfTokenFromState || csrfTokenFromState !== csrfTokenStored) {
-      res.clearCookie('oauth_csrf_token', { path: '/' }); // 검증 실패 시에도 삭제
-      return res.redirect(
-        'http://localhost:3000/auth/callback?errorCode=INVALID_OAUTH_STATE'
-      );
-    }
-
-    const { access_token } = await exchangeCodeForToken(code, state);
-    const naverUser = await getNaverUser(access_token);
-
-    const user = await authService.findOrCreateOAuthUser({
+export const naverCallback: RequestHandler = (req, res) =>
+  handleOAuthCallback(req, res, {
+    name: 'naver',
+    exchangeCodeForToken,
+    getUserInfo: ({ access_token }) => getNaverUser(access_token),
+    mapUser: (naverUser) => ({
       email: naverUser.email,
       name: naverUser.name,
       profileImage: naverUser.profile_image,
-      provider: 'naver',
-      role: roleFromState as ROLE,
-    });
+    }),
+  });
 
-    const { accessToken, refreshToken } =
-      authService.createTokenByUserData(user);
-
-    res.cookie('refreshToken', refreshToken, {
-      httpOnly: true,
-      secure: false,
-      sameSite: 'strict',
-      path: '/',
-      maxAge: 1000 * 60 * 60 * 24 * 7,
-    });
-
-    res.cookie('accessToken', accessToken, {
-      httpOnly: true,
-      secure: false,
-      sameSite: 'strict',
-      path: '/',
-      maxAge: 1000 * 60 * 60,
-    });
-
-    res.clearCookie('oauth_csrf_token', { path: '/' }); // 성공 후에도 삭제
-
-    res.redirect('http://localhost:3000/auth/callback');
-  } catch (e) {
-    if (typeof e === 'object' && e && 'errorCode' in e) {
-      const { errorCode, data } = e as {
-        errorCode: string;
-        data?: Record<string, string>;
-      };
-
-      const query = new URLSearchParams({ errorCode, ...data }).toString();
-      return res.redirect(`http://localhost:3000/auth/callback?${query}`);
-    }
-
-    return res.redirect(
-      `http://localhost:3000/auth/callback?errorCode=UNKNOWN_ERROR`
-    );
-  }
-};
-
-export default {
-  naverLoginRedirect,
-  naverCallback,
-};
+export default { naverLoginRedirect, naverCallback };

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -1,0 +1,112 @@
+import { ROLE } from '@prisma/client';
+import { Request, Response } from 'express';
+import authService from './auth.service';
+
+interface OAuthProvider {
+  name: 'google' | 'kakao' | 'naver';
+  exchangeCodeForToken: (code: string, state: string) => Promise<any>;
+  getUserInfo: (tokens: any) => Promise<any>;
+  mapUser: (raw: any) => {
+    email: string;
+    name: string;
+    profileImage: string;
+  };
+}
+
+/**
+ * OAuth 콜백 공통 처리 함수
+ */
+export async function handleOAuthCallback(
+  req: Request,
+  res: Response,
+  provider: OAuthProvider
+) {
+  try {
+    const code = req.query.code as string;
+    const state = req.query.state as string; // csrfToken, role 포함
+    const [csrfTokenFromState, roleFromState] = state.split('|');
+    const csrfTokenStored = req.cookies['oauth_csrf_token'];
+
+    // CSRF 토큰 검증 실패 시 쿠키 제거 후 리다이렉트
+    if (!csrfTokenFromState || csrfTokenFromState !== csrfTokenStored) {
+      res.clearCookie('oauth_csrf_token', { path: '/' }); // 검증 실패 시에도 삭제
+      return res.redirect(
+        'http://localhost:3000/auth/callback?errorCode=INVALID_OAUTH_STATE'
+      );
+    }
+
+    // OAuth 토큰 교환 및 사용자 정보 조회
+    const tokens = await provider.exchangeCodeForToken(code, state);
+    const rawUser = await provider.getUserInfo(tokens);
+    const { email, name, profileImage } = provider.mapUser(rawUser);
+
+    // 사용자 생성 또는 조회
+    const user = await authService.findOrCreateOAuthUser({
+      email,
+      name,
+      profileImage,
+      provider: provider.name,
+      role: roleFromState as ROLE,
+    });
+
+    // 액세스/리프레시 토큰 발급 및 쿠키 저장
+    const { accessToken, refreshToken } =
+      authService.createTokenByUserData(user);
+
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: false,
+      sameSite: 'strict',
+      path: '/',
+      maxAge: 1000 * 60 * 60 * 24 * 7,
+    });
+
+    res.cookie('accessToken', accessToken, {
+      httpOnly: true,
+      secure: false,
+      sameSite: 'strict',
+      path: '/',
+      maxAge: 1000 * 60 * 60,
+    });
+
+    res.clearCookie('oauth_csrf_token', { path: '/' }); // 성공 후에도 삭제
+    res.redirect('http://localhost:3000/auth/callback'); // 프론트로 이동
+  } catch (e) {
+    // 에러 발생 시 프론트로 errorCode와 provider, role 등 전달
+    if (typeof e === 'object' && e && 'errorCode' in e) {
+      const { errorCode, data } = e as {
+        errorCode: string;
+        data?: Record<string, string>;
+      };
+      const query = new URLSearchParams({ errorCode, ...data }).toString();
+      return res.redirect(`http://localhost:3000/auth/callback?${query}`);
+    }
+    // 예상치 못한 에러
+    return res.redirect(
+      `http://localhost:3000/auth/callback?errorCode=UNKNOWN_ERROR`
+    );
+  }
+}
+
+/**
+ * OAuth 리다이렉트 URL 생성 및 쿠키 설정 공통 처리 함수
+ */
+export function handleOAuthRedirect(
+  state: string,
+  getAuthURL: (state: string) => string,
+  res: Response
+) {
+  const [csrfToken] = state.split('|');
+
+  // 백엔드 도메인 기준 쿠키 저장 (콜백에서 검증용)
+  res.cookie('oauth_csrf_token', csrfToken, {
+    httpOnly: true,
+    secure: false, // http 환경에서는 false, https 환경에선 true
+    sameSite: 'lax', // 외부 리다이렉트 흐름에서도 쿠키 전송 허용
+    path: '/',
+    maxAge: 5 * 60 * 1000,
+  });
+
+  const url = getAuthURL(state); // 소셜 로그인 URL 생성
+  res.redirect(url);
+}


### PR DESCRIPTION
- 문제
    - 콘트롤러들에 서비스 로직 포함
    - 중복 코드 반복
- 해결
    - 각 서비스별 콘트롤러 파일에 있던 리다이렉트, 콜백, 토큰 발급 등의 코드를 공통 로직으로 분리
        - services/oauth.service.ts
    - 기존 콘트롤러 코드에서 해당 부분 삭제 → 가독성 향상, 책임과 역할 분리 명확화
        - 콘트롤러에서 서비스 로직 삭제