### PR TITLE
[엄성민] fix: 유저 정보 수정 api 에 provider 값 추가

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -19,7 +19,8 @@ const getUserMeController: RequestHandler = asyncHandler(
 const updateUserMeController: RequestHandler = asyncHandler(
   async (req, res, next) => {
     const userId = req.userId as string;
-    const { email, password, newPassword, name, phoneNumber } = req.body;
+    const { email, password, newPassword, name, phoneNumber, provider } =
+      req.body;
     const updateUserDto: UpdateUserDto = {
       userId,
       email,
@@ -27,6 +28,7 @@ const updateUserMeController: RequestHandler = asyncHandler(
       newPassword,
       name,
       phoneNumber,
+      provider,
     };
     await userService.updateUserInfo(updateUserDto);
 

--- a/src/services/estimate-request.sevice.ts
+++ b/src/services/estimate-request.sevice.ts
@@ -206,7 +206,7 @@ const countEstimateRequests = async ({
       "officeMove",
     ];
 
-    const serviceTypeCounts = allServiceTypes.reduce<Record<string, number>>(
+    const serviceTypeCount = allServiceTypes.reduce<Record<string, number>>(
       (acc, type) => {
         const found = serviceTypeRawCounts.find(
           (entry) => entry.serviceType === type
@@ -254,7 +254,7 @@ const countEstimateRequests = async ({
       },
     });
 
-    return { ...serviceTypeCounts, serviceAreaCount, assignedCount };
+    return { ...serviceTypeCount, serviceAreaCount, assignedCount };
   } catch (e) {
     throw e;
   }

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -60,20 +60,38 @@ const getProfileImage = async (userId: string) => {
 //유저 정보 업데이트하는 함수
 const updateUserInfo = async (updateUserDto: UpdateUserDto) => {
   try {
-    const { userId, password, newPassword, ...rest } = updateUserDto;
+    const {
+      userId,
+      password,
+      newPassword,
+      provider = "local",
+      ...rest
+    } = updateUserDto;
     const user = await prisma.user.findFirst({ where: { id: userId } });
     if (!user) {
       throw new Error("400/user not found");
     }
     // 비밀번호 확인하기
-    await checkPassword(password, user.encryptedPassword);
-    // 비밀번호 생성
 
+    if (provider === "local") {
+      await checkPassword(password, user.encryptedPassword);
+    }
+
+    // 비밀번호 생성
     if (newPassword) {
       const encryptedPassword = await bcrypt.hash(newPassword, 12);
       await prisma.user.update({
         where: { id: userId },
         data: { ...rest, encryptedPassword },
+        include: {
+          workProfile: { select: { profileImage: true } },
+          customerProfile: { select: { profileImage: true } },
+        },
+      });
+    } else {
+      await prisma.user.update({
+        where: { id: userId },
+        data: { ...rest },
         include: {
           workProfile: { select: { profileImage: true } },
           customerProfile: { select: { profileImage: true } },

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -1,4 +1,4 @@
-import { ROLE } from "@prisma/client";
+import { Provider, ROLE } from "@prisma/client";
 
 type PayloadData = {
   id: string;
@@ -28,6 +28,7 @@ type UpdateUserDto = {
   newPassword: string;
   name: string;
   phoneNumber: string;
+  provider?: Provider;
 };
 
 export { LogInDto, PayloadData, SignUpDto, UpdateUserDto };

--- a/src/validations/auth.validation.ts
+++ b/src/validations/auth.validation.ts
@@ -1,4 +1,4 @@
-import { ROLE } from "@prisma/client";
+import { Provider, ROLE } from "@prisma/client";
 import { RequestHandler } from "express";
 import { z } from "zod";
 
@@ -45,22 +45,21 @@ const updateUserInfoSchema = z
   .object({
     email: emailSchema,
     name: nameSchema,
-    password: passwordSchema,
+    password: passwordSchema.optional(),
     newPasswordConfirm: passwordSchema.optional(),
     phoneNumber: phoneNumberSchema,
+    provider: z
+      .nativeEnum(Provider, { message: "Invalid provider" })
+      .optional(),
     newPassword: z
       .string()
       .min(8, { message: "새 비밀번호는 8자 이상이어야 합니다" })
       .regex(passwordRegex, "영문/숫자/특수문자를 모두 포함해야 합니다")
       .optional(),
   })
-  .refine(
-    (data) =>
-      data.newPasswordConfirm === data.newPassword,
-    {
-      message: "password don't match ",
-    }
-  )
+  .refine((data) => data.newPasswordConfirm === data.newPassword, {
+    message: "password don't match ",
+  })
   .refine((data) => !data.newPassword || data.newPassword !== data.password, {
     message: "새로운 비밀번호가 현재 비밀번호와 달라야합니다.",
   });
@@ -118,6 +117,7 @@ const validateUpdateUserInfo: RequestHandler = (req, res, next) => {
       newPasswordConfirm,
       phoneNumber,
       newPassword,
+      provider,
     } = req.body;
 
     const parsedContext = updateUserInfoSchema.safeParse({
@@ -127,6 +127,7 @@ const validateUpdateUserInfo: RequestHandler = (req, res, next) => {
       newPasswordConfirm,
       phoneNumber,
       newPassword,
+      provider,
     });
 
     if (!parsedContext.success) {


### PR DESCRIPTION
유저 정보 수정 api 수정
- provider 값을 받을 수 있도록 변경 (입력 하지 않으면 local이 기본값)
- 유저 정보가 수정되지 않았던 오류 수정
- provider 값이 local이 아닐경우에는 비밀번호 없이 수정 가능